### PR TITLE
Fix colors in accessibility Increase Contrast mode

### DIFF
--- a/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerCell.swift
+++ b/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerCell.swift
@@ -137,7 +137,7 @@ class CalendarDateRangePickerCell: UICollectionViewCell {
     }
 
     @objc func setBlackBoldFont() {
-        label.textColor = getPreferredColor(.black, accessibilityColor: .white)
+        label.textColor =  UIAccessibility.isDarkerSystemColorsEnabled ? .white : .black
         label.font = highlightedFont
     }
 
@@ -191,13 +191,3 @@ extension CalendarDateRangePickerCell {
         static let hint = "Double tap to choose the week that contains this date"
     }
 }
-
-// MARK: - Accessibility
-
- extension CalendarDateRangePickerCell {
-     public func getPreferredColor(_ color: UIColor, accessibilityColor: UIColor) -> UIColor {
-         return UIColor { _ in
-             return UIAccessibility.isDarkerSystemColorsEnabled ? accessibilityColor : color
-         }
-     }
- }

--- a/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerCell.swift
+++ b/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerCell.swift
@@ -137,7 +137,7 @@ class CalendarDateRangePickerCell: UICollectionViewCell {
     }
 
     @objc func setBlackBoldFont() {
-        label.textColor = .black
+        label.textColor = getPreferredColor(.black, accessibilityColor: .white)
         label.font = highlightedFont
     }
 
@@ -191,3 +191,13 @@ extension CalendarDateRangePickerCell {
         static let hint = "Double tap to choose the week that contains this date"
     }
 }
+
+// MARK: - Accessibility
+
+ extension CalendarDateRangePickerCell {
+     public func getPreferredColor(_ color: UIColor, accessibilityColor: UIColor) -> UIColor {
+         return UIColor { _ in
+             return UIAccessibility.isDarkerSystemColorsEnabled ? accessibilityColor : color
+         }
+     }
+ }

--- a/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerViewController.swift
+++ b/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerViewController.swift
@@ -178,7 +178,13 @@ extension CalendarDateRangePickerViewController {
                 cell.disable()
             }
 
-            if self.nowDatePreFormatted == datePreFormatted{
+            if self.nowDatePreFormatted == datePreFormatted {
+                cell.todaySelectedColor = cell.getPreferredColor(self.todaySelectedColor,
+                                                                 accessibilityColor:
+                                                                    selectedStartDate != nil &&
+                                                                 selectedEndDate != nil &&
+                                                                 isBefore(dateA: selectedStartDate!, dateB: date) &&
+                                                                 isBefore(dateA: date, dateB: selectedEndDate!) ? .white : .black)
                 cell.selectToday()
             }
 
@@ -283,7 +289,6 @@ extension CalendarDateRangePickerViewController {
             fatalError("Unexpected element kind")
         }
     }
-
 }
 
 extension CalendarDateRangePickerViewController: UICollectionViewDelegateFlowLayout {

--- a/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerViewController.swift
+++ b/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerViewController.swift
@@ -178,13 +178,13 @@ extension CalendarDateRangePickerViewController {
                 cell.disable()
             }
 
-            if self.nowDatePreFormatted == datePreFormatted {
-                cell.todaySelectedColor = cell.getPreferredColor(self.todaySelectedColor,
-                                                                 accessibilityColor:
-                                                                    selectedStartDate != nil &&
-                                                                 selectedEndDate != nil &&
-                                                                 isBefore(dateA: selectedStartDate!, dateB: date) &&
-                                                                 isBefore(dateA: date, dateB: selectedEndDate!) ? .white : .black)
+            if self.nowDatePreFormatted == datePreFormatted{
+                cell.todaySelectedColor = UIAccessibility.isDarkerSystemColorsEnabled ?
+                (selectedStartDate != nil &&
+                 selectedEndDate != nil &&
+                 isBefore(dateA: selectedStartDate!, dateB: date) &&
+                 isBefore(dateA: date, dateB: selectedEndDate!) ? .white : .black) :
+                self.todaySelectedColor
                 cell.selectToday()
             }
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust calendar date picker colors to respect the system’s Increase Contrast accessibility setting by introducing a helper that switches between default and high-contrast colors.

Bug Fixes:
- Use the new helper to set the black bold font and today’s selection color so text and highlights remain readable in Increase Contrast mode.

Enhancements:
- Add getPreferredColor helper to choose between standard and accessibility colors based on UIAccessibility.isDarkerSystemColorsEnabled.