### PR TITLE
[MOBILE-6977] Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "CalendarDateRangePicker",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "CalendarDateRangePicker",
+            targets: ["CalendarDateRangePicker"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "CalendarDateRangePicker",
+            path: "CalendarDateRangePickerViewController/Classes"
+        )
+    ]
+)


### PR DESCRIPTION
Add Package.swift to enable SPM as a dependency manager alongside CocoaPods. The package exposes CalendarDateRangePicker as a library target, pointing to the existing source files in CalendarDateRangePickerViewController/Classes.